### PR TITLE
chore: remove unused react imports and turn off eslint rule asking for them

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -37,6 +37,7 @@
                 "html": true
             }
         ],
+        "react/react-in-jsx-scope": "off",
         "@typescript-eslint/consistent-type-imports": [
             "error",
             {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from "react";
-import React from "react";
 import { Route, Routes } from "react-router-dom";
 import Calendar from "./components/Calendar";
 import ProtectedRoute from "./components/ProtectedRoute";

--- a/frontend/src/__test__/App.test.tsx
+++ b/frontend/src/__test__/App.test.tsx
@@ -1,5 +1,4 @@
 import { render } from "@testing-library/react";
-import React from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import App from "../App";
 

--- a/frontend/src/__test__/components/EventForm.test.tsx
+++ b/frontend/src/__test__/components/EventForm.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import React from "react";
 import EventForm from "../../components/EventForm";
 
 describe("EventForm", () => {

--- a/frontend/src/__test__/components/GroupForm.test.tsx
+++ b/frontend/src/__test__/components/GroupForm.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import React from "react";
 import GroupForm from "../../components/GroupForm";
 
 describe("GroupForm", () => {

--- a/frontend/src/__test__/components/ProtectedRoute.test.tsx
+++ b/frontend/src/__test__/components/ProtectedRoute.test.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { render, screen } from "@testing-library/react";
-import React from "react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import ProtectedRoute from "../../components/ProtectedRoute";
 import { AuthContext } from "../../context/AuthContext";

--- a/frontend/src/__test__/pages/CreateEventPage.test.tsx
+++ b/frontend/src/__test__/pages/CreateEventPage.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import React from "react";
 
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import CreateEventPage from "../../pages/CreateEventPage";

--- a/frontend/src/__test__/pages/CreateGroupPage.test.tsx
+++ b/frontend/src/__test__/pages/CreateGroupPage.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import React from "react";
 
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import CreateGroupPage from "../../pages/CreateGroupPage";

--- a/frontend/src/__test__/pages/HomePage.test.tsx
+++ b/frontend/src/__test__/pages/HomePage.test.tsx
@@ -1,5 +1,4 @@
 import { render } from "@testing-library/react";
-import React from "react";
 
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import HomePage from "../../pages/HomePage";

--- a/frontend/src/__test__/pages/LandingPage.test.tsx
+++ b/frontend/src/__test__/pages/LandingPage.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from "@testing-library/react";
-import React from "react";
 
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import LandingPage from "../../pages/LandingPage";

--- a/frontend/src/components/Calendar.tsx
+++ b/frontend/src/components/Calendar.tsx
@@ -1,7 +1,7 @@
 import { addDays, addHours, addMinutes, startOfDay } from "date-fns";
 import formatDate from "date-fns/format";
 import type { ReactElement } from "react";
-import React, { useEffect } from "react";
+import { cloneElement, useEffect, useState } from "react";
 import styled from "styled-components";
 import "./Calendar.css";
 
@@ -24,7 +24,7 @@ const Grid = styled.div<{ columns: number; rows: number }>`
 `;
 
 const Calendar = (props: CalendarPropsType): ReactElement => {
-    const [dates, setDates] = React.useState<CalendarDateType>([[new Date(0)]]);
+    const [dates, setDates] = useState<CalendarDateType>([[new Date(0)]]);
     const cellToDate: Map<Element, Date> = new Map();
 
     useEffect((): void => {
@@ -106,13 +106,13 @@ const Calendar = (props: CalendarPropsType): ReactElement => {
             <div key="topleft" />,
             // top row with the dates
             ...dates.map((dayOfTimes, index) =>
-                React.cloneElement(renderDateLabel(dayOfTimes[0]), {
+                cloneElement(renderDateLabel(dayOfTimes[0]), {
                     key: `date-${index}`
                 })
             ),
             // every row below that
             ...dateGridElements.map((element, index) =>
-                React.cloneElement(element, { key: `time-${index}` })
+                cloneElement(element, { key: `time-${index}` })
             )
         ];
     };

--- a/frontend/src/components/EventCard.tsx
+++ b/frontend/src/components/EventCard.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from "react";
-import React from "react";
 import "../components/EventCard.css";
 
 type EventCardProps = {

--- a/frontend/src/components/EventForm.tsx
+++ b/frontend/src/components/EventForm.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent, ReactElement } from "react";
-import React from "react";
+import { useState } from "react";
 import "./EventForm.css";
 
 type FormData = {
@@ -11,7 +11,7 @@ type FormData = {
 };
 
 const EventForm = (): ReactElement => {
-    const [formData, setFormData] = React.useState<FormData>({
+    const [formData, setFormData] = useState<FormData>({
         eventId: 0,
         groupId: 0,
         eventName: "",

--- a/frontend/src/components/GroupForm.tsx
+++ b/frontend/src/components/GroupForm.tsx
@@ -1,5 +1,5 @@
 import type { ChangeEvent, ReactElement } from "react";
-import React from "react";
+import { useState } from "react";
 import "./GroupForm.css";
 
 type FormData = {
@@ -11,7 +11,7 @@ type FormData = {
 };
 
 const GroupForm = (): ReactElement => {
-    const [formData, setFormData] = React.useState<FormData>({
+    const [formData, setFormData] = useState<FormData>({
         groupId: "",
         groupName: "",
         groupUrl: "",

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from "react";
-import React from "react";
 import { NavLink } from "react-router-dom";
 import "../components/Navbar.css";
 import { useAuth } from "../context/AuthContext";

--- a/frontend/src/components/ProtectedRoute.tsx
+++ b/frontend/src/components/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from "react";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../context/AuthContext";
 import type AuthProviderPropsType from "../context/AuthProviderPropsType";

--- a/frontend/src/context/AuthProvider.tsx
+++ b/frontend/src/context/AuthProvider.tsx
@@ -1,11 +1,11 @@
 import type { ReactElement } from "react";
-import React, { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { AuthContext } from "./AuthContext";
 import type AppContextDataType from "./AuthContextDataType";
 import type AuthProviderPropsType from "./AuthProviderPropsType";
 
 const AuthProvider = ({ children }: AuthProviderPropsType): ReactElement => {
-    const [token, setToken] = React.useState(null);
+    const [token, setToken] = useState(null);
 
     useEffect(() => {
         const localStorageToken = JSON.parse(

--- a/frontend/src/pages/CreateEventPage.tsx
+++ b/frontend/src/pages/CreateEventPage.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from "react";
-import React from "react";
 import EventForm from "../components/EventForm";
 import Navbar from "../components/Navbar";
 

--- a/frontend/src/pages/CreateGroupPage.tsx
+++ b/frontend/src/pages/CreateGroupPage.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from "react";
-import React from "react";
 import GroupForm from "../components/GroupForm";
 import Navbar from "../components/Navbar";
 

--- a/frontend/src/pages/HomePage.tsx
+++ b/frontend/src/pages/HomePage.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from "react";
-import React from "react";
 import EventCard from "../components/EventCard";
 import Navbar from "../components/Navbar";
 import "../pages/HomePage.css";

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,5 +1,4 @@
 import type { ReactElement } from "react";
-import React from "react";
 import "../App.css";
 import Navbar from "../components/Navbar";
 import { useAuth } from "../context/AuthContext";


### PR DESCRIPTION
## Describe your changes
Eslint was forcing us to import React into every component even if we didn't need to. This PR removes that eslint rule and removes all unnecessary react imports

- [x] wait for all pending PRs to finish

## Github Issue ID
Closes #72 

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
