### PR TITLE
chore: add cargo-watch to automatically reload backend on change

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -5,6 +5,7 @@ use std::net::SocketAddr;
 async fn main() {
     let app = Router::new()
         .route("/", get(|| async { "Hello World" }));
+
         
     let addr = SocketAddr::from(([0, 0, 0, 0], 9000));
 


### PR DESCRIPTION
## Describe your changes

Adds cargo-watch, essentially nodemon for Rust. Instead of running `cargo run` to spin up the server locally, use `cargo watch -x run` to receive automatic reruns on changes.

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
