### PR TITLE
feat: add server-side monitoring with prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,9 @@ start_app:
 stop_app:
 	docker-compose down
 
+start_with_monitoring:
+	docker-compose --profile monitoring up
+
 test_backend:
 	$(CD_BACKEND) && \
 	cargo test

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ lint_backend:
 
 lint_fix_backend:
 	$(CD_BACKEND) && \
-	cargo fmt --all && cargo clippy --fix
+	cargo fmt --all && cargo clippy --fix --allow-staged
 
 lint_frontend:
 	$(CD_FRONTEND) && \

--- a/assets/monitoring/prometheus.yaml
+++ b/assets/monitoring/prometheus.yaml
@@ -1,0 +1,17 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+scrape_configs:
+  - job_name: 'prometheus'
+    honor_timestamps: true
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: 'backend'
+    honor_timestamps: true
+    static_configs:
+      - targets: ['backend:9000']
+  - job_name: 'frontend'
+    honor_timestamps: true
+    static_configs:
+      - targets: ['frontend:8080']

--- a/assets/monitoring/prometheus.yml
+++ b/assets/monitoring/prometheus.yml
@@ -7,11 +7,8 @@ scrape_configs:
     honor_timestamps: true
     static_configs:
       - targets: ['localhost:9090']
+
   - job_name: 'backend'
     honor_timestamps: true
     static_configs:
-      - targets: ['backend:9000']
-  - job_name: 'frontend'
-    honor_timestamps: true
-    static_configs:
-      - targets: ['frontend:8080']
+      - targets: ['localhost:9000']

--- a/assets/monitoring/prometheus.yml
+++ b/assets/monitoring/prometheus.yml
@@ -11,4 +11,4 @@ scrape_configs:
   - job_name: 'backend'
     honor_timestamps: true
     static_configs:
-      - targets: ['localhost:9000']
+      - targets: ['host.docker.internal:9000']

--- a/assets/scripts/pre-commit
+++ b/assets/scripts/pre-commit
@@ -1,3 +1,6 @@
+set -e
+set -o pipefail
+
 HAS_BACKEND_CHANGED=$(git diff --cached --name-only -- backend/)
 HAS_FRONTEND_CHANGED=$(git diff --cached --name-only -- frontend/)
 

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -84,10 +95,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-prometheus"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97def327c5481791abb57ac295bfc70f2e1a0727675b7dbf74bd1b27a72b6fd8"
+dependencies = [
+ "axum",
+ "axum-core",
+ "bytes",
+ "futures",
+ "futures-core",
+ "http",
+ "http-body",
+ "matchit",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "once_cell",
+ "pin-project",
+ "tokio",
+ "tower",
+ "tower-http",
+]
+
+[[package]]
 name = "backend"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "axum-prometheus",
  "hyper",
  "postgres",
  "tokio",
@@ -180,6 +215,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-epoch"
+version = "0.9.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +285,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -242,6 +314,23 @@ name = "futures-core"
 version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
 
 [[package]]
 name = "futures-macro"
@@ -272,10 +361,13 @@ version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -307,6 +399,21 @@ name = "gimli"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ff8ae62cd3a9102e5637afc8452c55acf3844001bd5374e0b0bd7b6616c038"
+dependencies = [
+ "ahash",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -387,6 +494,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
+
+[[package]]
 name = "itoa"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +547,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "mach2"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d0d1830bcd151a6fc4aea1369af235b36c1528fe976b8ff678683c9995eade8"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -444,6 +576,70 @@ name = "memchr"
 version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
+
+[[package]]
+name = "memoffset"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "metrics"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde3af1a009ed76a778cb84fdef9e7dbbdf5775ae3e4cc1f434a6a307f6f76c5"
+dependencies = [
+ "ahash",
+ "metrics-macros",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a4964177ddfdab1e3a2b37aec7cf320e14169abb0ed73999f558136409178d5"
+dependencies = [
+ "base64",
+ "hyper",
+ "indexmap",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddece26afd34c31585c74a4db0630c376df271c285d682d1e55012197830b6df"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de2ed6e491ed114b40b732e4d1659a9d53992ebd87490c44a6ffe23739d973e"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.13.1",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mime"
@@ -576,6 +772,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "portable-atomic"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31114a898e107c51bb1609ffaf55a0e011cf6a4d7f1170d0015a165082c0338b"
+
+[[package]]
 name = "postgres"
 version = "0.19.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +836,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e662a7a8291a865152364c20c7abc5e60486ab2001e8ec10b24862de0b9ab"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "mach2",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +888,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "10.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -776,6 +1003,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68a406c1882ed7f29cd5e248c9848a80e7cb6ae0fea82346d2746f2f941c07e1"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -843,6 +1076,26 @@ name = "sync_wrapper"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "thiserror"
+version = "1.0.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "tinyvec"
@@ -982,7 +1235,19 @@ dependencies = [
  "cfg-if",
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 axum = "0.6.20"
+axum-prometheus = "0.4.0"
 hyper = "0.14.27"
 postgres = "0.19.7"
 tokio = { version = "1.32.0", features = ["macros", "rt-multi-thread"] }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -20,7 +20,7 @@ FROM alpine:latest
 WORKDIR /app
 COPY --from=build-stage ./app/target/release/. .
 EXPOSE 9000
-CMD ["./backend"]
+CMD ["./schedulii_backend"]
 
 # Notes on Dockerfile
 # To build: `docker build -t backend .`

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,8 +1,8 @@
 use crate::handlers::hello_world::hello_world;
 use axum::{routing::get, Router, Server};
-use axum_prometheus::{PrometheusMetricLayer};
-use std::net::SocketAddr;
 use axum_prometheus::metrics_exporter_prometheus::PrometheusHandle;
+use axum_prometheus::PrometheusMetricLayer;
+use std::net::SocketAddr;
 
 mod handlers;
 
@@ -20,9 +20,7 @@ async fn main() {
         .unwrap();
 }
 
-fn app(
-    metric_handler: PrometheusHandle,
-) -> Router {
+fn app(metric_handler: PrometheusHandle) -> Router {
     Router::new()
         .route("/", get(hello_world))
         .route("/metrics", get(|| async move { metric_handler.render() }))
@@ -32,6 +30,7 @@ fn app(
 mod tests {
     use super::app;
     use axum::body::Body;
+
     use axum::http::{Request, StatusCode};
     use axum_prometheus::PrometheusMetricLayer;
     use tower::ServiceExt;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,12 +1,16 @@
 use crate::handlers::hello_world::hello_world;
 use axum::{routing::get, Router, Server};
+use axum_prometheus::{PrometheusMetricLayer};
 use std::net::SocketAddr;
+use axum_prometheus::metrics_exporter_prometheus::PrometheusHandle;
 
 mod handlers;
 
 #[tokio::main]
 async fn main() {
-    let app = app();
+    let (prometheus_layer, metric_handler) = PrometheusMetricLayer::pair();
+    let app = app(metric_handler);
+    let app = app.layer(prometheus_layer);
 
     let addr = SocketAddr::from(([0, 0, 0, 0], 9000));
 
@@ -16,8 +20,12 @@ async fn main() {
         .unwrap();
 }
 
-fn app() -> Router {
-    Router::new().route("/", get(hello_world))
+fn app(
+    metric_handler: PrometheusHandle,
+) -> Router {
+    Router::new()
+        .route("/", get(hello_world))
+        .route("/metrics", get(|| async move { metric_handler.render() }))
 }
 
 #[cfg(test)]
@@ -25,12 +33,15 @@ mod tests {
     use super::app;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
+    use axum_prometheus::PrometheusMetricLayer;
     use tower::ServiceExt;
 
     // reference from https://github.com/tokio-rs/axum/blob/main/examples/testing/src/main.rs
     #[tokio::test]
     async fn main() {
-        let app = app();
+        let (prometheus_layer, metric_handler) = PrometheusMetricLayer::pair();
+        let app = app(metric_handler);
+        let app = app.layer(prometheus_layer);
 
         let response = app
             .oneshot(Request::builder().uri("/").body(Body::empty()).unwrap())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yml'
     ports:
       - "9090:9090"
+
     volumes:
       - ./assets/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
       - monitoring_data:/prometheus
@@ -55,7 +56,7 @@ services:
     ports:
       - "3000:3000"
     profiles:
-      - monitoring
+      - grafana
 
 volumes:
   monitoring_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,3 +60,6 @@ services:
 
 volumes:
   monitoring_data:
+
+networks:
+  default:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,13 @@ services:
       context: ./backend
     ports:
       - "9000:9000"
+
   frontend:
     build: 
       context: ./frontend/schedulii-ui
     ports:
       - "8080:80"
+
   database:
     image: postgres
     environment:
@@ -28,3 +30,32 @@ services:
       timeout: 60s
       retries: 5
       start_period: 80s
+
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    restart: always
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./assets/monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+      - monitoring_data:/prometheus
+    profiles:
+      - monitoring
+
+  grafana:
+    image: grafana/grafana
+    container_name: grafana
+    restart: always
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=grafana
+    ports:
+      - "3000:3000"
+    profiles:
+      - monitoring
+
+volumes:
+  monitoring_data:


### PR DESCRIPTION
## Describe your changes
- add metric collection to rust backend using axum-prometheus
- you can start the application with monitoring by using `make start_with_monitoring`
  - starts up a prometheus container that will monitor on server's /metrics endpoint
  - check out prometheus on `localhost:9090`
- edit pre-commit hook to fail if checks fail

## Github Issue ID
N/A

## Checklist before requesting a review
- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
