### PR TITLE
fix: ci-pipeline when on main branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,7 @@ jobs:
 
       # This line is needed for nx affected to work when CI is running on a PR
       - run: git branch --track main origin/main
+        if: github.ref != 'refs/heads/main'
 
       - run: npx nx format:check
 


### PR DESCRIPTION
## Describe your changes

There's a line in the github actions `ci.yaml` that makes ci fail when running on the main branch. Added a condition to only trigger than line during PRs

## Github Issue ID

Closes N/A

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
