### PR TITLE
fix: use nx to generate tailwind configs

### DIFF
--- a/apps/schedulii-ui/postcss.config.js
+++ b/apps/schedulii-ui/postcss.config.js
@@ -1,6 +1,15 @@
+const { join } = require('path');
+
+// Note: If you use library-specific PostCSS/Tailwind configuration then you should remove the `postcssConfig` build
+// option from your application's configuration (i.e. project.json).
+//
+// See: https://nx.dev/guides/using-tailwind-css-in-react#step-4:-applying-configuration-to-libraries
+
 module.exports = {
   plugins: {
-    tailwindcss: {},
+    tailwindcss: {
+      config: join(__dirname, 'tailwind.config.js'),
+    },
     autoprefixer: {},
-  }
-}
+  },
+};

--- a/apps/schedulii-ui/src/styles/index.css
+++ b/apps/schedulii-ui/src/styles/index.css
@@ -1,3 +1,3 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/apps/schedulii-ui/tailwind.config.js
+++ b/apps/schedulii-ui/tailwind.config.js
@@ -1,8 +1,17 @@
+const { createGlobPatternsForDependencies } = require('@nx/react/tailwind');
+const { join } = require('path');
+
 /** @type {import('tailwindcss').Config} */
-export default {
-	content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],
-	theme: {
-		extend: {},
-	},
-	plugins: [],
+module.exports = {
+  content: [
+    join(
+      __dirname,
+      '{src,pages,components,app}/**/*!(*.stories|*.spec).{ts,tsx,html}'
+    ),
+    ...createGlobPatternsForDependencies(__dirname),
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
 };


### PR DESCRIPTION
## Describe your changes

Tailwind was not rendering styles properly in this NX repo. Had to use the NX tailwind generator to properly ensure styles were rendering.

## Github Issue ID

Closes N/A

## Checklist before requesting a review

- [X] I have performed a self-review of my code
- [X] If it is a core feature, I have added thorough tests.
